### PR TITLE
fix: remove RunAsNonRoot from backup CronJob pods

### DIFF
--- a/internal/controller/kopiabackup/builder.go
+++ b/internal/controller/kopiabackup/builder.go
@@ -180,7 +180,6 @@ func buildCronJob(
 						},
 						Spec: corev1.PodSpec{
 							SecurityContext: &corev1.PodSecurityContext{
-								RunAsNonRoot: ptr.To(true),
 								SeccompProfile: &corev1.SeccompProfile{
 									Type: corev1.SeccompProfileTypeRuntimeDefault,
 								},


### PR DESCRIPTION
## Problem

All snapshot CronJob pods fail with `Init:CreateContainerConfigError`:

```
container has runAsNonRoot and image has non-numeric user (root), cannot verify user is non-root
```

The Kopia container image (`ghcr.io/fastlorenzo/kopia`) runs as root, which is needed for NFS mount operations and file-level backup access.

## Fix

Remove `RunAsNonRoot: true` from the backup pod security context. All other security constraints remain:
- Seccomp profile (RuntimeDefault)
- Container-level: no privilege escalation, drop ALL caps, read-only rootfs