### PR TITLE
fix(controller): persist CronJob spec changes on reconcile

### DIFF
--- a/internal/controller/kopiabackup/reconciler.go
+++ b/internal/controller/kopiabackup/reconciler.go
@@ -441,15 +441,23 @@ func (r *KopiaBackupReconciler) reconcileCronJob(
 		return fmt.Errorf("failed to get CronJob: %w", err)
 	}
 
+	// Snapshot the current spec BEFORE mutating so the change detection below
+	// compares the actual cluster state against the desired state. Comparing the
+	// already-mutated copy against desired would always be equal and skip the
+	// Update (e.g. node affinity would never get persisted after the CronJob was
+	// first created without a running pod).
+	originalSpec := existing.Spec.DeepCopy()
+
 	existing.Spec.Schedule = desired.Spec.Schedule
 	existing.Spec.Suspend = desired.Spec.Suspend
 	existing.Spec.ConcurrencyPolicy = desired.Spec.ConcurrencyPolicy
 	existing.Spec.SuccessfulJobsHistoryLimit = desired.Spec.SuccessfulJobsHistoryLimit
 	existing.Spec.FailedJobsHistoryLimit = desired.Spec.FailedJobsHistoryLimit
+	existing.Spec.JobTemplate.Spec.Template.ObjectMeta = desired.Spec.JobTemplate.Spec.Template.ObjectMeta
 	existing.Spec.JobTemplate.Spec.Template.Spec = desired.Spec.JobTemplate.Spec.Template.Spec
 	existing.Spec.JobTemplate.Spec.Suspend = desired.Spec.JobTemplate.Spec.Suspend
 
-	if equality.Semantic.DeepEqual(existing.Spec, desired.Spec) {
+	if equality.Semantic.DeepEqual(originalSpec, &existing.Spec) {
 		return nil
 	}
 	return r.Update(ctx, existing)

--- a/internal/controller/kopiabackup/reconciler_test.go
+++ b/internal/controller/kopiabackup/reconciler_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	backupv1alpha1 "github.com/fastlorenzo/kopia-operator/api/backup/v1alpha1"
+	"github.com/fastlorenzo/kopia-operator/internal/naming"
 )
 
 var _ = Describe("KopiaBackup Controller", func() {
@@ -192,6 +194,88 @@ var _ = Describe("KopiaBackup Controller", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should re-apply node affinity on an existing CronJob that lacks it", func() {
+			// Regression test: reconcileCronJob used to compare the already-mutated
+			// "existing" object against "desired", which made the equality check
+			// always true and skipped the Update. A CronJob created while no pod was
+			// running (no affinity) would therefore never get node affinity even
+			// after a pod started, leaving snapshot pods stuck on the wrong node.
+			controllerReconciler := &KopiaBackupReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: record.NewFakeRecorder(10),
+			}
+
+			const targetNode = "worker-node-1"
+
+			By("creating a running pod that mounts the PVC on a specific node")
+			consumerPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc-consumer",
+					Namespace: namespace,
+					Labels:    map[string]string{"app.kubernetes.io/name": "consumer"},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: targetNode,
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "busybox",
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							},
+						},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, consumerPod)).To(Succeed())
+			// Pod phase is part of status and must be set after creation.
+			consumerPod.Status.Phase = corev1.PodRunning
+			Expect(k8sClient.Status().Update(ctx, consumerPod)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, consumerPod)
+			})
+
+			By("reconciling so the CronJob gets created with affinity")
+			// First reconcile adds the finalizer, second does the real work.
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			cronJobKey := types.NamespacedName{
+				Name:      naming.CronJobName(pvcName),
+				Namespace: namespace,
+			}
+			cronJob := &batchv1.CronJob{}
+			Expect(k8sClient.Get(ctx, cronJobKey, cronJob)).To(Succeed())
+			Expect(cronJob.Spec.JobTemplate.Spec.Template.Spec.Affinity).NotTo(BeNil(),
+				"CronJob should have node affinity after reconcile with a running pod")
+
+			By("simulating the broken legacy state: stripping affinity from the CronJob")
+			cronJob.Spec.JobTemplate.Spec.Template.Spec.Affinity = nil
+			Expect(k8sClient.Update(ctx, cronJob)).To(Succeed())
+
+			By("reconciling again should re-apply the affinity (Update must not be skipped)")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			fixed := &batchv1.CronJob{}
+			Expect(k8sClient.Get(ctx, cronJobKey, fixed)).To(Succeed())
+			affinity := fixed.Spec.JobTemplate.Spec.Template.Spec.Affinity
+			Expect(affinity).NotTo(BeNil(), "affinity must be restored on reconcile")
+			Expect(affinity.NodeAffinity).NotTo(BeNil())
+			terms := affinity.NodeAffinity.
+				RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions[0].Key).To(Equal("kubernetes.io/hostname"))
+			Expect(terms[0].MatchExpressions[0].Values).To(ContainElement(targetNode))
 		})
 	})
 })


### PR DESCRIPTION
## Problem

`reconcileCronJob` never persists spec drift to existing CronJobs.

It fetches the live CronJob into `existing`, copies the desired fields into it, and then compares the **already-mutated** `existing` against `desired`:

```go
existing.Spec.JobTemplate.Spec.Template.Spec = desired.Spec.JobTemplate.Spec.Template.Spec
...
if equality.Semantic.DeepEqual(existing.Spec, desired.Spec) { // always true now
    return nil
}
return r.Update(ctx, existing) // never reached
```

Because `existing` was just overwritten with the desired values, the comparison is always equal, so `r.Update()` is effectively dead code. Once a CronJob exists, its spec is never reconciled again.

### Real-world impact (observed on a live cluster)

Snapshot CronJobs created while **no consumer pod was running** get `affinity: nil` (since `buildNodeAffinity("")` returns nil). When the application pod later starts, the reconciler computes the correct `kubernetes.io/hostname` node affinity — but never persists it.

The snapshot pod then schedules on an arbitrary node. For **RWO Ceph block PVCs** already attached to the app pod on another node, the volume can't attach and the snapshot pod hangs forever in `Init:0/1`. On the affected cluster this left 8 backups stuck for ~6 days (frigate, home-assistant, emqx, jellyfin, openclaw x2, prowlarr, hass code-server).

This is the same drift that #4 (`d1f12f1`, watch Pods to keep affinity current) tried to address by re-triggering reconciles — but the re-triggered reconcile still couldn't write the change because of this comparison bug.

## Fix

- Snapshot the original spec **before** mutating and compare `originalSpec` vs the updated `existing.Spec` to decide whether to call `Update`.
- Also sync `JobTemplate.Spec.Template.ObjectMeta` so the `backup.cloudinfra.be/node-name` pod label stops drifting from the actual affinity.

## Test

Adds an envtest regression spec that:
1. Creates a running pod mounting the PVC on a known node.
2. Reconciles -> CronJob gets node affinity.
3. Strips the affinity (simulating the legacy broken state).
4. Reconciles again -> asserts the affinity is restored to the right node.

Verified the test **fails** against the old comparison and **passes** with the fix. Full suite: 31/31 specs pass; `go build`, `go vet`, and `gofmt` all clean.

## Remediation for already-broken CronJobs

Existing CronJobs created before this fix still carry no affinity until they're updated. After this lands, a one-time nudge (annotate the affected KopiaBackups, or restart the operator so the pod-watch fires) lets the reconciler write the correct affinity. Stuck `Init:0/1` snapshot pods should be deleted so the next scheduled run reschedules with affinity.